### PR TITLE
Allow parsing of an assertion name to a asserts_json assertion

### DIFF
--- a/lib/riot/gear/context/asserts_json.rb
+++ b/lib/riot/gear/context/asserts_json.rb
@@ -27,8 +27,8 @@ module Riot
       # @param [String] json_string a JSON looking path
       # @param [lambda] &handler an optional block for filtering the actual value
       # @return [Riot::Assertion] an assertion block that macros can be applied to
-      def asserts_json(json_string, &handler)
-        asserts("value from body as json:#{json_string}") do
+      def asserts_json(json_string, name = '', &handler)
+        asserts("value from body as json:#{json_string} #{name}") do
           value = json_path(response, json_string)
           handler ? handler.call(value) : value
         end

--- a/test/assertions/asserts_json_test.rb
+++ b/test/assertions/asserts_json_test.rb
@@ -15,4 +15,8 @@ context "The asserts_json macro" do
     value.map { |string, number| number }
   end.equals([1,2])
   
+  asserts_json("c", "custom assert") do |value|
+    value.map { |string, number| number }
+  end.equals([1,2])
+  
 end # The asserts_json macro


### PR DESCRIPTION
Allows usage of an option name for an asserts_json to make output clearer
`asserts_json('foo.bar', "is a value")` prints `asserts value from body as json:foo.bar is a value`
